### PR TITLE
Add streaming logic for local development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,10 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+	"extensions": [
+		"ms-python.python",
+		"ms-azuretools.vscode-docker"
+	]
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "python.pythonPath": "/usr/local/bin/python",
+    // I added this setting for avoiding unexpected error in VS Code
+    // https://stackoverflow.com/questions/40163106/cannot-find-col-function-in-pyspark
     "python.linting.pylintArgs": [
         "--generated-members=pyspark.*",
         "--extension-pkg-whitelist=pyspark",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "python.pythonPath": "/usr/local/bin/python",
+    "python.linting.pylintArgs": [
+        "--generated-members=pyspark.*",
+        "--extension-pkg-whitelist=pyspark",
+        "--ignored-modules=pyspark.sql.functions",
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # streaming-dataops
-sample repo for understanding spark structured streaming and data ops
+- Sample repo for understanding spark structured streaming and data ops
+- You can utilize device simulator in my [GitHub](https://github.com/NT-D/streaming-dataops-device)
+
+## Run app
+1. Set environment variable with event hub (IoT Hub) information
+```
+export EVENTHUB_CONNECTION_STRING="{Your event hub connection string}"
+export EVENTHUB_NAMESPACE="{Your event hub name space}"
+export EVENT_HUB_NAME="{Your event hub name}"
+```
+1. Run `pyspark --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.0.0 < stream_app.py` to execute structred streaming. It shows kafka messages in console.
+
+### environment variable example
+Uses `xxx` for mocking secrets
+|Name|Example|
+|--|--|
+|EVENTHUB_CONNECTION_STRING| `Endpoint=sb://xxx.servicebus.windows.net/;SharedAccessKeyName=xxxxx;SharedAccessKey=xxx;EntityPath=xxxx`|
+|EVENTHUB_NAMESPACE|`xxxx.servicebus.windows.net`|
+|EVENT_HUB_NAME|Unique event hub name such as `streaming-ops-masota`|
+
+
+## Refer
+https://github.com/Azure/azure-event-hubs-for-kafka/tree/master/tutorials/spark#running-spark
+
+Update vscode setting for resolving pyspark import error problem
+https://stackoverflow.com/questions/40163106/cannot-find-col-function-in-pyspark
+
+Structured Streaming + Kafka Integration Guide (Kafka broker version 0.10.0 or higher)
+https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html

--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
+TODO: 
+- Documentation
+    - Update repository problem statement (motivation) and goal.
+    - Add architecutre diagram
+- Add Unit test
+- Add CI/CD pipeline including submit spark jobs
+- Monitor streaming and alert to admin team whenever streaming job fail
+
 # streaming-dataops
 - Sample repo for understanding spark structured streaming and data ops
 - You can utilize device simulator in my [GitHub](https://github.com/NT-D/streaming-dataops-device). It can send expected telemetry to IoT Hub and Spark.
 
-## Run app
+## How to run app
+1. If you are new for developing inside a container, please read [this document](https://code.visualstudio.com/docs/remote/containers) and setup environment by refering [Getting started](https://code.visualstudio.com/docs/remote/containers#_getting-started).
+1. Clone and open repository inside the container with [this document](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume).
 1. Set environment variable with event hub (IoT Hub) information
-```
+```shell
 export EVENTHUB_CONNECTION_STRING="{Your event hub connection string}"
 export EVENTHUB_NAMESPACE="{Your event hub name space}"
 export EVENT_HUB_NAME="{Your event hub name}"
 ```
-1. Run `pyspark --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.0.0 < stream_app.py` to execute structred streaming. It shows kafka messages in console.
+4. Run `pyspark --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.0.0 < stream_app.py` in Visual Studio Code terminal to execute structred streaming. It shows telemetry in console.
 
 ### environment variable example
 |Name|Example|IoT Hub Build-in endpoints name|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # streaming-dataops
 - Sample repo for understanding spark structured streaming and data ops
-- You can utilize device simulator in my [GitHub](https://github.com/NT-D/streaming-dataops-device)
+- You can utilize device simulator in my [GitHub](https://github.com/NT-D/streaming-dataops-device). It can send expected telemetry to IoT Hub and Spark.
 
 ## Run app
 1. Set environment variable with event hub (IoT Hub) information

--- a/README.md
+++ b/README.md
@@ -12,19 +12,26 @@ export EVENT_HUB_NAME="{Your event hub name}"
 1. Run `pyspark --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.0.0 < stream_app.py` to execute structred streaming. It shows kafka messages in console.
 
 ### environment variable example
-Uses `xxx` for mocking secrets
-|Name|Example|
-|--|--|
-|EVENTHUB_CONNECTION_STRING| `Endpoint=sb://xxx.servicebus.windows.net/;SharedAccessKeyName=xxxxx;SharedAccessKey=xxx;EntityPath=xxxx`|
-|EVENTHUB_NAMESPACE|`xxxx.servicebus.windows.net`|
-|EVENT_HUB_NAME|Unique event hub name such as `streaming-ops-masota`|
+|Name|Example|IoT Hub Build-in endpoints name|
+|--|--|--|
+|EVENTHUB_CONNECTION_STRING|`Endpoint=sb://xxx.servicebus.windows.net/;  SharedAccessKeyName=xxxxx;SharedAccessKey=xxx;EntityPath=xxxx`|Event Hub-compatible endpoint|
+|EVENTHUB_NAMESPACE|`xxxx.servicebus.windows.net`|Pick up from `Event Hub-compatible endpoint string`|
+|EVENT_HUB_NAME|Unique event hub name such as `streaming-ops-masota`|Event Hub-compatible name|
+
+- Uses `xxx` for mocking secrets
+- If you use Azure IoT Hubs, please refer 3rd column to pick up connection setting from [built-in endpoint](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin)
 
 
-## Refer
-https://github.com/Azure/azure-event-hubs-for-kafka/tree/master/tutorials/spark#running-spark
+## Reference
+### DataOps strategy
+For understanding concept of this repo, please read following repo and blog
+- [DataOps for the Modern Data Warehouse](https://github.com/Azure-Samples/modern-data-warehouse-dataops)
+- [Spark Streaming part 3: DevOps, tools and tests for Spark applications](https://www.adaltas.com/en/2019/06/19/spark-devops-tools-test/)
 
-Update vscode setting for resolving pyspark import error problem
-https://stackoverflow.com/questions/40163106/cannot-find-col-function-in-pyspark
+### Spark structured streaming and Azure Event Hubs
+- [Connect your Apache Spark application with Azure Event Hubs](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-kafka-spark-tutorial)
+- [Structured Streaming + Kafka Integration Guide (Kafka broker version 0.10.0 or higher)](https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html)
+- [Structured Streaming Programming Guide](http://spark.apache.org/docs/latest/structured-streaming-programming-guide.html)
 
-Structured Streaming + Kafka Integration Guide (Kafka broker version 0.10.0 or higher)
-https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html
+### Setup development environment
+- [Update vscode setting for resolving pyspark import error problem](https://stackoverflow.com/questions/40163106/cannot-find-col-function-in-pyspark)

--- a/dfcreate.py
+++ b/dfcreate.py
@@ -5,7 +5,7 @@ from pyspark.sql.functions import col
 spark = SparkSession.builder.master('local').getOrCreate()
 
 # Define data schema, then set data
-user_row = Row('birth','age','is_fan')
+user_row = Row('birth', 'age', 'is_fan')
 
 data = [
     user_row('1990-01-01', 29, True),

--- a/stream_app.py
+++ b/stream_app.py
@@ -19,13 +19,17 @@ EH_SASL = f'org.apache.kafka.common.security.plain.PlainLoginModule required \
     username="$ConnectionString" password="{EVENTHUB_CONNECTION_STRING}";'
 BOOTSTRAP_SERVERS = f'{EVENTHUB_NAMESPACE}:9093'
 
+streaming_config = {
+    "kafka.sasl.mechanism": "PLAIN",
+    "kafka.security.protocol": "SASL_SSL",
+    "kafka.sasl.jaas.config": EH_SASL,
+    "kafka.bootstrap.servers": BOOTSTRAP_SERVERS,
+    "subscribe": EVENT_HUB_NAME
+}
+
 rowStreamDf = spark.readStream \
     .format("kafka") \
-    .option("kafka.sasl.mechanism", "PLAIN") \
-    .option("kafka.security.protocol", "SASL_SSL") \
-    .option("kafka.sasl.jaas.config", EH_SASL) \
-    .option("kafka.bootstrap.servers", BOOTSTRAP_SERVERS) \
-    .option("subscribe", EVENT_HUB_NAME) \
+    .options(**streaming_config) \
     .load() \
     .select(col("value").cast("STRING"))
 

--- a/stream_app.py
+++ b/stream_app.py
@@ -35,7 +35,7 @@ schema = StructType([
 
 schemaedStreamDf = rowStreamDf.select(from_json("value", schema).alias("json")) \
     .select(col("json.temperature").alias("temperature"),
-            col("json.humidity").alias("humidity")
+            col("json.humidity").alias("humidity") \
     )
 
 # Write data in the console

--- a/stream_app.py
+++ b/stream_app.py
@@ -48,5 +48,10 @@ schemaedStreamDf = rowStreamDf.select(from_json("value", schema).alias("json")) 
     )
 
 # Write data in the console
-stream = schemaedStreamDf.writeStream.outputMode('append').format('console').start()
-stream.awaitTermination()
+try:
+    stream = schemaedStreamDf.writeStream.outputMode('append').format('console').start()
+    stream.awaitTermination()
+except:
+    # If the query has terminated with an exception, then the exception will be thrown.
+    # Can write code for sending alert/email to IT admin to know
+    print("Streaming is terminated by exception")

--- a/stream_app.py
+++ b/stream_app.py
@@ -7,12 +7,14 @@ from pyspark.sql.types import StructType, StructField, DoubleType
 # spark = SparkSession.builder.master('local').getOrCreate()
 spark = SparkSession.builder.appName('StructredStreamingApp').getOrCreate()
 
-# Azure setting information
+# Get Azure setting information from environmental variable
 EVENTHUB_CONNECTION_STRING = os.getenv('EVENTHUB_CONNECTION_STRING')
 EVENTHUB_NAMESPACE = os.getenv('EVENTHUB_NAMESPACE')
 EVENT_HUB_NAME = os.getenv('EVENT_HUB_NAME') # same as kafka topic
 
-# Kafka stream settings
+# Connect IoT Hub from Spark
+# IoT Hub has Event Hub compatible build-in endpoint. Event Hub is compatible with Kafka.
+# Use Kafka connector in this repo because developers sometimes want to use Kafka in the onpremises.
 EH_SASL = f'org.apache.kafka.common.security.plain.PlainLoginModule required \
     username="$ConnectionString" password="{EVENTHUB_CONNECTION_STRING}";'
 BOOTSTRAP_SERVERS = f'{EVENTHUB_NAMESPACE}:9093'
@@ -28,6 +30,9 @@ rowStreamDf = spark.readStream \
     .select(col("value").cast("STRING"))
 
 # Set and apply schema
+# Created simulator device in another repo and send random temperature and humidity to IoT Hub
+# https://github.com/NT-D/streaming-dataops-device/blob/master/simulator.py
+# This part uses same schema with the repository.
 schema = StructType([
     StructField("temperature", DoubleType(), True),
     StructField("humidity", DoubleType(), True)

--- a/stream_app.py
+++ b/stream_app.py
@@ -1,0 +1,32 @@
+import os
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col
+
+# Initialize spark env
+# spark = SparkSession.builder.master('local').getOrCreate()
+spark = SparkSession.builder.appName('StructredStreamingApp').getOrCreate()
+
+# Azure setting information
+EVENTHUB_CONNECTION_STRING = os.getenv('EVENTHUB_CONNECTION_STRING')
+EVENTHUB_NAMESPACE = os.getenv('EVENTHUB_NAMESPACE')
+EVENT_HUB_NAME = os.getenv('EVENT_HUB_NAME') # same as kafka topic
+
+# Kafka stream settings
+EH_SASL = f'org.apache.kafka.common.security.plain.PlainLoginModule required \
+    username="$ConnectionString" password="{EVENTHUB_CONNECTION_STRING}";'
+BOOTSTRAP_SERVERS = f'{EVENTHUB_NAMESPACE}:9093'
+
+myDf = spark.readStream \
+    .format("kafka") \
+    .option("kafka.sasl.mechanism", "PLAIN") \
+    .option("kafka.security.protocol", "SASL_SSL") \
+    .option("kafka.sasl.jaas.config", EH_SASL) \
+    .option("kafka.bootstrap.servers", BOOTSTRAP_SERVERS) \
+    .option("subscribe", EVENT_HUB_NAME) \
+    .load()
+#   .select(col("value").cast("STRING"))             # Cast the "value" column to STRING
+
+
+# Write data in the console
+query = myDf.writeStream.outputMode('append').format('console').start()
+query.awaitTermination()


### PR DESCRIPTION
## Why
For providing high quality code to the production, we want to test code, automate CI/CD pipeline as engineering fundamental. On the other hand, there are few documents/repo to describe how to achieve this. For helping other developers, I started to create repository.

## What I implement in this PR
- Added structed streaming logic (stream_app.py)
- Updated Readme file to describe how to run app with public kafka library

## What I've done in past PR
- Prepare local Spark environment as development container (see .devcontainer folder)

## Out of scope in this PR
- Unit test
- Document about how to setup IoT Hubs and [device simulator](https://github.com/NT-D/streaming-dataops-device).